### PR TITLE
Fix performance on locked "Head- Tail lights" by removing unnecessary state updates

### DIFF
--- a/common/src/main/java/net/adeptstack/ctl/behaviours/movement/HeadTailLightMovementBehaviour.java
+++ b/common/src/main/java/net/adeptstack/ctl/behaviours/movement/HeadTailLightMovementBehaviour.java
@@ -40,7 +40,6 @@ public class HeadTailLightMovementBehaviour implements MovementBehaviour {
         context.data.putInt("OpenTicks", ticksOpen);
         if (ticksOpen > 20) {
             BlockPos pos = context.localPos;
-            int oldLightMode = context.state.getValue(HeadTailLightBlockBase.LIGHT_MODE);
             if (context.contraption.entity instanceof CarriageContraptionEntity cce && context.contraption instanceof CarriageContraption cc) {
                 Direction assemblyDirection = cc.getAssemblyDirection();
                 if (assemblyDirection == Direction.UP || assemblyDirection == Direction.DOWN) {
@@ -80,77 +79,74 @@ public class HeadTailLightMovementBehaviour implements MovementBehaviour {
                     value = globalP.subtract(globalN);
                 }
 
-                if (direction == Direction.NORTH) {
-                    if (value.z > 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.z > 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.z < 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.z < 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    }
-                } else if (direction == Direction.EAST) {
-                    if (value.x > 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.x > 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.x < 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.x < 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    }
-                } else if (direction == Direction.SOUTH) {
-                    if (value.z > 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.z > 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.z < 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.z < 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    }
-                } else if (direction == Direction.WEST) {
-                    if (value.x > 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.x > 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.x < 0 && localXZ > 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    } else if (value.x < 0 && localXZ < 0) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    }
-                }
-
                 if (locked) {
-                    if (context.state.getValue(HeadTailLightBlockBase.LIGHT_MODE) != oldLightMode) {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, oldLightMode);
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIT, false);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    }
-                    else {
-                        context.state = context.state .setValue(HeadTailLightBlockBase.LIT, true);
-                        context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
-                    }
+                    context.state = context.state .setValue(HeadTailLightBlockBase.LIT, true);
+                    context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+                } else {
+                    tickLightMode(context, value, direction, localXZ, pos, structureBlockInfo);
                 }
             }
             context.data.putInt("OpenTicks", 0);
+        }
+    }
+
+    private void tickLightMode(MovementContext context, Vec3 value, Direction direction, int localXZ, BlockPos pos, StructureTemplate.StructureBlockInfo structureBlockInfo) {
+        if (direction == Direction.NORTH) {
+            if (value.z > 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.z > 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.z < 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.z < 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            }
+        } else if (direction == Direction.EAST) {
+            if (value.x > 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.x > 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.x < 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.x < 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            }
+        } else if (direction == Direction.SOUTH) {
+            if (value.z > 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.z > 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.z < 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.z < 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            }
+        } else if (direction == Direction.WEST) {
+            if (value.x > 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.x > 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.x < 0 && localXZ > 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 0);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            } else if (value.x < 0 && localXZ < 0) {
+                context.state = context.state .setValue(HeadTailLightBlockBase.LIGHT_MODE, 1);
+                context.contraption.entity.setBlock(pos, new StructureTemplate.StructureBlockInfo(pos, context.state, structureBlockInfo.nbt()));
+            }
         }
     }
 


### PR DESCRIPTION
When these lights were in the locked mode, they were updated when the driving direction did not match their configured value and immediately updated back to the old value (since they were locked).
This behavior caused lag spikes because Create had to update the train twice for each misconfigured light, even though updates were unwanted.
Now, the light mode checks are only run in the unlocked mode, which improves performance immensely.

This fixes the issue #13 